### PR TITLE
Update page title for BlazorDay 2025 to include event details

### DIFF
--- a/src/Sot.BlazorDay2025.Website/wwwroot/index.html
+++ b/src/Sot.BlazorDay2025.Website/wwwroot/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <base href="/" />
-  <title>BlazorDay 2025</title>
+  <title>BlazorDay 2025 - 3rd edition - September 25th, 2025 - The online conf about Blazor</title>
   <link rel="stylesheet" href="css/app.css" />
   <link href="Sot.BlazorDay2025.Website.styles.css" rel="stylesheet" />
 

--- a/src/Sot.BlazorDay2025.Website/wwwroot/index.html
+++ b/src/Sot.BlazorDay2025.Website/wwwroot/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <base href="/" />
-  <title>BlazorDay 2025 - 3rd edition - September 25th, 2025 - The online conf about Blazor</title>
+  <title>BlazorDay 2025 - 3rd edition - September 25th, 2025 - The online conference about Blazor</title>
   <link rel="stylesheet" href="css/app.css" />
   <link href="Sot.BlazorDay2025.Website.styles.css" rel="stylesheet" />
 


### PR DESCRIPTION
This pull request includes an update to the `index.html` file to enhance the website's title for better clarity and branding.

* [`src/Sot.BlazorDay2025.Website/wwwroot/index.html`](diffhunk://#diff-4191970bf7f8a06678a69c7b8ddca3f2f7e917950c4bb1b5f4414e0b178ef814L8-R8): Updated the `<title>` tag to include additional details about the event, specifying it as the "3rd edition," the date (September 25th, 2025), and its nature as an online conference about Blazor.