### PR TITLE
Allow to trigger manualy the github action

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,7 +8,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-
+  workflow_dispatch:
+    
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
This pull request updates the `.github/workflows/dotnet.yml` file to allow manual triggering of the workflow via the GitHub Actions interface.

Workflow configuration update:

* Added `workflow_dispatch` to the `on:` section, enabling the workflow to be triggered manually. (`[.github/workflows/dotnet.ymlR11](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344R11)`)